### PR TITLE
Release 1.7.2 add group scan fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Lichborne are documented in this file.
 
 ## Unreleased
 
-## 1.7.1 - 2026-03-26
+## 1.7.2 - 2026-03-26
 
 ### Added
 
@@ -21,6 +21,7 @@ All notable changes to Lichborne are documented in this file.
 
 ### Fixed
 
+- Fixed Add Group scan actions on 3.3.5a so UI handlers bind the local scan-state helper instead of calling a missing global `SetScanActive` when addon hook stacks are present.
 - Fixed inspect slot mapping so equipped item levels are read from the correct gear slots.
 - Fixed All tab actions so add, delete, and sync operations act on the displayed character.
 - Fixed tracker deletion cleanup so removing a character also clears roster and needs references.

--- a/LichborneTracker/LichborneTracker.lua
+++ b/LichborneTracker/LichborneTracker.lua
@@ -3985,6 +3985,8 @@ local function OnFirstShow()
     end)
 
     -- ── Add Group button ───────────────────────────────────────
+    local SetScanActive
+
     local addGroupBtn = CreateFrame("Button", "LichborneAddGroupBtn", f)
     addGroupBtn:SetPoint("BOTTOMLEFT", f, "BOTTOMLEFT", 175, 112)
     addGroupBtn:SetSize(155, 28)
@@ -4273,7 +4275,7 @@ local function OnFirstShow()
     local activeInspectFrame = nil  -- shared by GS and Spec scans; Stop button kills it
 
     -- Disable/enable all buttons except Stop during a scan
-    local function SetScanActive(active)
+    SetScanActive = function(active)
         SetButtonsLocked(active)
         -- Also lock invite buttons during scans (they aren't Stop Invite here)
         local inviteRaid = _G["LichborneInviteRaidBtn"]
@@ -4691,7 +4693,7 @@ local function OnFirstShow()
     infoText:SetText(
         "|cffd4af37LICHBORNE|r\n" ..
         "|cffd4af37Gear Tracker & Raid Planner|r\n" ..
-        "|cffd4af37v1.7.1|r\n" ..
+        "|cffd4af37v1.7.2|r\n" ..
         "\n" ..
         "|cffaaaaaaQuestions & Support:|r\n" ..
         "|cffd4af37lichborne.wow|r\n" ..
@@ -4782,7 +4784,7 @@ local function BuildFrameBG()
     title:SetPoint("TOPLEFT", f, "TOPLEFT", 10, -12)
     title:SetPoint("TOPRIGHT", f, "TOPRIGHT", -280, -12)
     title:SetJustifyH("LEFT")
-    title:SetText("|cffC69B3ALICHBORNE|r  —  Gear Tracker  |cffaaaaaa v1.7.1|r")
+    title:SetText("|cffC69B3ALICHBORNE|r  —  Gear Tracker  |cffaaaaaa v1.7.2|r")
     local closeBtn = CreateFrame("Button", "LichborneCloseBtn", f, "UIPanelCloseButton")
     closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", 2, 2)
     closeBtn:SetScript("OnClick", function() f:Hide() end)

--- a/LichborneTracker/LichborneTracker.toc
+++ b/LichborneTracker/LichborneTracker.toc
@@ -2,7 +2,7 @@
 ## Title: |cffC69B3ALichborne|r Gear Tracker
 ## Notes: Guild raid gear tracker with tier color system
 ## Author: Lichborne
-## Version: 1.7.1
+## Version: 1.7.2
 ## SavedVariables: LichborneTrackerDB, LichborneMinimapIconDB
 
 # Libraries

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A World of Warcraft WotLK 3.3.5a Addon for AzerothCore Private Servers
 
-Version: 1.7.1
+Version: 1.7.2
 
 ---
 
@@ -16,6 +16,7 @@ Version: 1.7.1
 
 ## Recent Changes
 
+- **Add Group scan compatibility fix** — Group scan buttons now bind the local scan-state helper correctly on 3.3.5a, preventing `SetScanActive` nil errors reported through addon hook stacks such as BugSack or ElvUI.
 - **Addon load compatibility fix** — Bundled `CallbackHandler-1.0` is now loaded before `LibDataBroker-1.1`, and startup no longer hard-fails if the minimap broker stack is unavailable.
 - **3.3.5a-safe UI handlers** — Replaced fragile implicit handler globals like `this` and `arg1` with explicit script arguments to reduce conflicts with other addons.
 - **Gear Score average bar in Class tabs** — Each class tab now displays an average GearScore bar alongside the existing average iLvl bar.


### PR DESCRIPTION
This updates the addon to 1.7.2 and fixes a 3.3.5a compatibility issue in the group scan flow.

Summary:

- Fixes the SetScanActive nil error triggered from Add Group scan actions when other addon hook stacks are present.
- Forward-declares the local scan-state helper so early UI handlers bind correctly.
- Bumps visible addon version metadata from 1.7.1 to 1.7.2.
- Updates changelog and README to document the fix.

Testing:

Reloaded addon logic reviewed for Add Group / Add Group GS call paths.
Verified the fix is isolated to scan-state binding and does not change scan behavior.